### PR TITLE
Fix a bug relating #80

### DIFF
--- a/pyviewer/core/__version__.py
+++ b/pyviewer/core/__version__.py
@@ -1,1 +1,1 @@
-VERSION = "3.2.2"
+VERSION = "3.2.3"

--- a/pyviewer/viewers/tar.py
+++ b/pyviewer/viewers/tar.py
@@ -92,22 +92,24 @@ def show_tar(tar_file: tarfile.TarFile,
     return RM('\n'.join(res), False)
 
 
-def get_contents(tar_file, path):
-    path = str(path)
-    if path == '.':
+def get_contents(tar_file: tarfile.TarFile, path: PurePosixPath):
+    cpath = str(path)
+    if cpath == '.':
         lenpath = 0
     else:
-        lenpath = len(path)+1
+        lenpath = len(cpath)+1
     files = []
     dirs = []
     for t in tar_file.getmembers():
-        if lenpath != 0:
-            if t.name == path:
+        tpath = PurePosixPath(t.name)
+        if lenpath != 0:  # not root
+            if t.name == cpath:
                 continue
-            if not t.name.startswith(path):
+            if path not in tpath.parents:
                 continue
         tname = t.name[lenpath:]
         if '/' in tname:
+            # @ root dir, count "directoly added"(?) files.
             # in some case, directories are not listed?
             tmp_dir = tname.split('/')[0]
             if tmp_dir not in dirs:

--- a/pyviewer/viewers/tar.py
+++ b/pyviewer/viewers/tar.py
@@ -40,7 +40,7 @@ def show_tar(tar_file: tarfile.TarFile,
             outpath.parent.mkdir(parents=True)
         for item in tar_file.getmembers():
             logger.debug(f'checking;; {item.name}')
-            if item.name.startswith(cpath):
+            if cpath in [str(x) for x in PurePosixPath(item.name).parents]:
                 logger.info(f'  find; {item.name}')
                 tar_file.extract(item, path=outpath)
         return RM(f'file is saved to {outpath/cpath}', False)

--- a/pyviewer/viewers/zip.py
+++ b/pyviewer/viewers/zip.py
@@ -82,7 +82,7 @@ def show_zip(zip_file: zipfile.ZipFile, pwd: Optional[bytes],
             outpath.parent.mkdir(parents=True)
         for item in zip_file.namelist():
             logger.debug(f'checking;; {item}')
-            if item.startswith(cpath):
+            if cpath in [str(x) for x in PurePosixPath(item).parents]:
                 logger.info(f'  find; {item}')
                 zip_file.extract(zip_file.getinfo(item), path=outpath, pwd=pwd)
         return RM(f'file is saved to {outpath/cpath}', False)


### PR DESCRIPTION
#80 works incorrectly in some situations like 
-k test/tmp -o path/to/output
with the file including test/tmp1 directory.

A similar problem will happen in the tar file even if without -o option.